### PR TITLE
#11 feat make oauth signinsignup feature

### DIFF
--- a/backend/account/models.py
+++ b/backend/account/models.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import AbstractUser
 from django.db import models
+import uuid
 
 # Create your models here.
 
@@ -9,12 +10,16 @@ class User(AbstractUser):
     @brief User 모델 설정
     @details 사용자의 프로필 정보를 관리
 
+    @username 유저를 식별하는 고유한 문자열
     @imagePath 프로필 이미지 url path
     @nickname 유저가 스스로를 정의하는 별명
     @winCnt 유저의 1대1 매치 승리 횟수
     @loseCnt 유저의 1대1 매치 패배 횟수
     """
 
+    username = models.CharField(
+        max_length=36, unique=True, default=uuid.uuid4, editable=False
+    )
     imagePath = models.URLField(max_length=255, null=True)
     nickname = models.CharField(max_length=50, unique=True)
     winCnt = models.PositiveIntegerField(default=0)

--- a/backend/account/urls.py
+++ b/backend/account/urls.py
@@ -5,4 +5,5 @@ app_name = "account"
 
 urlpatterns = [
     path("oauth/token/", views.get_oauth_token),
+    path("oauth/callback/", views.callback),
 ]

--- a/backend/account/urls.py
+++ b/backend/account/urls.py
@@ -3,4 +3,6 @@ from . import views
 
 app_name = "account"
 
-urlpatterns = []
+urlpatterns = [
+    path("oauth/token/", views.get_oauth_token),
+]

--- a/backend/account/views.py
+++ b/backend/account/views.py
@@ -1,14 +1,173 @@
-import os
+import os, requests, random
+from django.conf import settings
+from django.http import JsonResponse, HttpResponseRedirect
 from django.shortcuts import redirect
-from django.http import HttpResponse
+from django.contrib.auth import get_user_model
+from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.decorators import api_view
 
-# Create your views here.
+User = get_user_model()
+
+from account.models import OAuth
 
 
 @api_view(["GET"])
 def get_oauth_token(request):
+    """
+    @brief 클라이언트를 42 API의 OAuth 인증 페이지로 리디렉션하는 함수
+
+    @param request Django의 HTTP 요청 객체
+
+    @return 42 API의 OAuth 인증 페이지로 리디렉션
+
+    @details
+    환경 변수에서 CLIENT_ID와 REDIRECT_URI를 읽어와 OAuth 인증 URL을 생성합니다.
+    생성된 URL로 리디렉션하여 42 인증을 시작합니다.
+    """
+
     client_id = os.environ.get("CLIENT_ID")
     redirect_uri = os.environ.get("REDIRECT_URI")
     authorize_uri = f"https://api.intra.42.fr/oauth/authorize?client_id={client_id}&redirect_uri={redirect_uri}&response_type=code&scope=public"
     return redirect(authorize_uri)
+
+
+def callback(request):
+    """
+    @brief 42 OAuth 인증 콜백을 처리하는 함수
+
+    @param request Django의 HTTP 요청 객체
+
+    @return
+        - 성공: JWT를 생성하여 사용자의 쿠키에 저장하고 기본 페이지(localhost)로 리디렉션
+        - 실패: 상태 코드와 에러 메시지를 JSON 형태로 반환
+
+    @details
+    42 API 서버로부터 받은 인증 코드를 사용하여 access_token 및 refresh_token을 요청한다.
+    access_token을 이용하여 42 API 서버에서 사용자 정보를 가져온다.
+    가져온 사용자 정보(인트라 ID, 이메일, 프로필 이미지 url)를 기반으로
+    OAuth 테이블에서 해당 사용자를 조회하여
+        - 동일한 유저가 없으면 새 사용자 정보를 데이터베이스에 저장하고 유저 객체를 통해
+        - 동일한 유저가 있으면 해당 유저 객체를 통해
+    JWT를 생성하여 사용자의 클라이언트 쿠키에 access_token과 refresh_token을 저장한다.
+    이후 사용자를 기본 페이지(http://localhost)로 리디렉션한다.
+    """
+    code = request.GET.get("code")
+    if not code:
+        return JsonResponse(
+            {
+                "error": "No authorization code in request",
+            },
+            status=400,
+        )
+    client_id = os.environ.get("CLIENT_ID")
+    client_secret = os.environ.get("CLIENT_SECRET")
+    redirect_uri = os.environ.get("REDIRECT_URI")
+    token_url = "https://api.intra.42.fr/oauth/token"
+    token_response = requests.post(
+        token_url,
+        data={
+            "grant_type": "authorization_code",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "code": code,
+            "redirect_uri": redirect_uri,
+        },
+    )
+    if token_response.status_code == 200:
+        access_token = token_response.json().get("access_token")
+        user_info = requests.get(
+            "https://api.intra.42.fr/v2/me",
+            headers={"Authorization": f"Bearer {access_token}"},
+        ).json()
+        intra_id = user_info.get("login")
+        user_email = user_info.get("email")
+        user_image_path = user_info.get("image", {}).get("link")
+        user, created = get_or_create_user_oauth(intra_id, user_email, user_image_path)
+        refresh = RefreshToken.for_user(user)
+        access = refresh.access_token
+        response = HttpResponseRedirect("http://localhost")
+        response.set_cookie(
+            key="access_token",
+            value=str(access),
+            httponly=True,
+            secure=False,  # 나중에 True로 변경
+            samesite="Lax",
+            max_age=settings.SIMPLE_JWT["ACCESS_TOKEN_LIFETIME"].total_seconds(),
+            path="/",
+        )
+        response.set_cookie(
+            key="refresh_token",
+            value=str(refresh),
+            httponly=True,
+            secure=False,  # 나중에 True로 변경
+            samesite="Lax",
+            max_age=settings.SIMPLE_JWT["REFRESH_TOKEN_LIFETIME"].total_seconds(),
+            path="/",
+        )
+        return response
+    else:
+        return JsonResponse(
+            {
+                "error": "Token Request Failed",
+            },
+            status=token_response.status_code,
+        )
+
+
+def generate_random_nickname():
+    """
+    @brief 랜덤한 유저 닉네임을 생성하는 함수
+
+    @param 없음
+
+    @return 다른 유저와 중복되지 않는 랜덤 생성된 유저의 닉네임
+
+    @details
+    10000 부터 99999 까지의 임의의 수를 무작위로 골라서 'USER#' 문자열 뒤에 붙인다.
+    User 테이블을 조회하여 랜덤 생성된 닉네임의 중복여부를 확인한다.
+        - 중복되었다면 새로운 랜덤 닉네임을 다시 생성한다.
+        - 중복되지 않았다면 해당 닉네임을 리턴한다.
+    최종적으로 중복되지 않은 닉네임을 리턴한다.
+    """
+    while True:
+        random_number = f"{random.randint(10000, 99999):05}"  # 5자리 숫자 생성
+        nickname = f"USER#{random_number}"
+        if not User.objects.filter(nickname=nickname).exists():  # 중복 확인
+            return nickname
+
+
+def get_or_create_user_oauth(intra_id, user_email, user_image_path):
+    """
+    @brief OAuth 인증을 통해 유저를 조회하거나 생성하는 함수
+
+    @param
+        - intra_id : 유저의 42 인트라 아이디
+        - user_email : 유저의 이메일
+        - user_image_path : 유저의 사진 url
+
+    @return 유저(user)와 생성 여부(bool created)
+
+    @details
+    OAuth 테이블에서 유저의 인트라아이디와 동일한 인트라아이디를 가진 객체가 있는지 탐색한다.
+        - 동일한 인트라 아이디를 가진 유저가 있다면 해당 유저와 생성 여부(false)를 리턴한다.
+        - 동일한 인트라 아이디를 가진 유저가 없다면 새롭게 유저 객체를 생성하고 연결된 OAuth 객체를 생성하여 해당 유저와 생성 여부(true)를 리턴한다.
+    """
+    try:
+        oauth_account = OAuth.objects.filter(intraId=intra_id).first()
+        if oauth_account:
+            user = oauth_account.user
+            created = False
+        else:
+            random_nickname = generate_random_nickname()
+            user, created = User.objects.get_or_create(
+                email=user_email,
+                defaults={
+                    "imagePath": user_image_path,
+                    "nickname": random_nickname,
+                },
+            )
+            if created:
+                OAuth.objects.create(user=user, intraId=intra_id)
+        return user, created
+    except Exception as e:
+        return None, False

--- a/backend/account/views.py
+++ b/backend/account/views.py
@@ -1,4 +1,14 @@
-from django.shortcuts import render
+import os
+from django.shortcuts import redirect
 from django.http import HttpResponse
+from rest_framework.decorators import api_view
 
 # Create your views here.
+
+
+@api_view(["GET"])
+def get_oauth_token(request):
+    client_id = os.environ.get("CLIENT_ID")
+    redirect_uri = os.environ.get("REDIRECT_URI")
+    authorize_uri = f"https://api.intra.42.fr/oauth/authorize?client_id={client_id}&redirect_uri={redirect_uri}&response_type=code&scope=public"
+    return redirect(authorize_uri)

--- a/backend/account/views.py
+++ b/backend/account/views.py
@@ -11,7 +11,6 @@ User = get_user_model()
 from account.models import OAuth
 
 
-@api_view(["GET"])
 def get_oauth_token(request):
     """
     @brief 클라이언트를 42 API의 OAuth 인증 페이지로 리디렉션하는 함수

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,6 @@
 Django==4.2.3
 psycopg2-binary==2.9.6
 black
+requests
 djangorestframework
+djangorestframework-simplejwt

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 Django==4.2.3
 psycopg2-binary==2.9.6
 black
+djangorestframework

--- a/backend/transcendence/settings.py
+++ b/backend/transcendence/settings.py
@@ -55,8 +55,6 @@ from datetime import timedelta
 SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(minutes=15),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=1),
-    "ROTATE_REFRESH_TOKENS": False,
-    "BLACKLIST_AFTER_ROTATION": True,
     "ALGORITHM": "HS256",
     "SIGNING_KEY": SECRET_KEY,
     "AUTH_HEADER_TYPES": ("Bearer",),

--- a/backend/transcendence/settings.py
+++ b/backend/transcendence/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "rest_framework",
     "account",
 ]
 

--- a/backend/transcendence/settings.py
+++ b/backend/transcendence/settings.py
@@ -40,8 +40,28 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "rest_framework",
+    "rest_framework_simplejwt",
     "account",
 ]
+
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
+    )
+}
+
+from datetime import timedelta
+
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=15),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=1),
+    "ROTATE_REFRESH_TOKENS": False,
+    "BLACKLIST_AFTER_ROTATION": True,
+    "ALGORITHM": "HS256",
+    "SIGNING_KEY": SECRET_KEY,
+    "AUTH_HEADER_TYPES": ("Bearer",),
+    "AUTH_TOKEN_CLASSES": ("rest_framework_simplejwt.tokens.AccessToken",),
+}
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
 
 networks:
     intra:
+        external: true
 
 volumes:
     pgdata:


### PR DESCRIPTION
# 42 OAuth를 통한 회원관리 및 JWT 발급 \#11
## Overview
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

User 테이블의 username 기본값을 UUID로 변경
- JWT 인증 과정에서 username이 사용자와 직접적으로 연관된 데이터를 포함할 경우, 보안상 위험 요소가 될 가능성 존재함. 
- 예측 불가능한 UUID를 username 기본값으로 설정하여 보안을 강화.

42 OAuth Authorization Code 발급을 위한 리다이렉트 함수 추가
- 프론트엔드에서 42 OAuth Authorization URI로 직접 리다이렉트하는 방식은 URI가 사용자에게 노출되어 보안상 문제가 발생할 수 있음.
- 서버에 요청을 보내 Authorization URI로 리다이렉트하도록 구현. 이를 통해 민감한 URI 정보가 클라이언트 측에서 노출되지 않고 서버 측에서 안전하게 처리됨.

42 OAuth Callback 함수 추가
- OAuth 인증 과정을 통해 42 서버로부터 유저 데이터를 받아옴
- 유저 데이터를 기반으로 사용자의 쿠키에 JWT를 저장하는 로직을 추가
- 유저가 데이터베이스에 등록되지 않은(회원가입 하지 않은) 경우에는 새로운 유저 데이터를 생성
- 쿠키를 발급하고 사용자를 기본페이지로 리다이렉트 시킴

<!---- Resolves: #(Isuue Number) -->
## PR Type
어떤 변경 사항이 있나요?

- [ ] feat

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
